### PR TITLE
Safe recovery

### DIFF
--- a/grpc.proto
+++ b/grpc.proto
@@ -31,8 +31,8 @@ message RecoverResponse {
 // Keygen's success response
 message KeygenOutput {
     bytes pub_key = 1;               // pub_key; common for all parties
-    bytes group_info = 2;            // public recovery info of all parties' shares; common for all parties
-    bytes recovery_info= 3; // private recovery info of this party's shares; unique for each party
+    bytes group_recover_info = 2;    // recovery info common for all parties
+    bytes private_recover_info = 3;  // recovery info unique for each party
 }
 
 // generic message types shared by Keygen, Sign

--- a/grpc.proto
+++ b/grpc.proto
@@ -28,6 +28,12 @@ message RecoverResponse {
     Response response = 1; 
 }
 
+// Keygen's success response
+message KeygenOutput {
+    bytes pub_key = 1;               // pub_key; common for all parties
+    bytes group_info = 2;            // recovery info of all parties' shares; common for all parties
+    repeated bytes recovery_info= 3; // private recovery info of this party's shares; unique for each party
+}
 
 // generic message types shared by Keygen, Sign
 
@@ -54,12 +60,6 @@ message MessageOut {
 
     // Keygen's response types
     message KeygenResult {
-        // Keygen's success response
-        message KeygenOutput {
-            bytes pub_key = 1;                       // pub_key 
-            repeated bytes share_recovery_infos = 2; // recovery nfo
-        }
-
         oneof keygen_result_data {
             KeygenOutput data = 1;       // Success response
             CriminalList criminals = 2;  // Failure response

--- a/grpc.proto
+++ b/grpc.proto
@@ -32,7 +32,7 @@ message RecoverResponse {
 message KeygenOutput {
     bytes pub_key = 1;               // pub_key; common for all parties
     bytes group_info = 2;            // public recovery info of all parties' shares; common for all parties
-    repeated bytes recovery_info= 3; // private recovery info of this party's shares; unique for each party
+    bytes recovery_info= 3; // private recovery info of this party's shares; unique for each party
 }
 
 // generic message types shared by Keygen, Sign

--- a/grpc.proto
+++ b/grpc.proto
@@ -31,7 +31,7 @@ message RecoverResponse {
 // Keygen's success response
 message KeygenOutput {
     bytes pub_key = 1;               // pub_key; common for all parties
-    bytes group_info = 2;            // recovery info of all parties' shares; common for all parties
+    bytes group_info = 2;            // public recovery info of all parties' shares; common for all parties
     repeated bytes recovery_info= 3; // private recovery info of this party's shares; unique for each party
 }
 

--- a/grpc.proto
+++ b/grpc.proto
@@ -16,7 +16,7 @@ service GG20 {
 
 message RecoverRequest {
     KeygenInit keygen_init = 1;
-    repeated bytes share_recovery_infos = 2; 
+    KeygenOutput keygen_output = 2;
 }
 
 message RecoverResponse { 


### PR DESCRIPTION
Update proto file to support safe recover. See a more detailed overview of the needed changes [here](https://github.com/axelarnetwork/tofnd/issues/146).

When keygen is completed, the server needs to send:
1. the `public key`. As before, common across all parties and **has to be voted on**.
2. the `common recovery info`. This info is common across all parties and **has to be voted on**.
3. the `private recovery info`. Encrypted info about all shares of one party. This info is unique per party.

The client currently aggregates all `secret_recovery_info` from all parties. This needs to change; The client needs to send the exact same info that is created by the server when keygen is completed, ie the `public key`, the `common recover info` and the `private recover info`.