### PR TITLE
chore(grpc): change type of `my_party_index` and `threshold` to uint32

### DIFF
--- a/grpc.proto
+++ b/grpc.proto
@@ -109,8 +109,8 @@ message KeygenInit {
     string new_key_uid = 1;
     repeated string party_uids = 2;
     repeated uint32 party_share_counts = 5;
-    int32 my_party_index = 3; // parties[my_party_index] belongs to the server
-    int32 threshold = 4;
+    uint32 my_party_index = 3; // parties[my_party_index] belongs to the server
+    uint32 threshold = 4;
 }
 
 // Sign-specific message types


### PR DESCRIPTION
Change my_party_index and my_party_index from int32 to uint32 according to [NCC#2](https://github.com/axelarnetwork/tofnd/issues/147) audit in tofnd.